### PR TITLE
feat:Populate role category on Task (RWA-945)

### DIFF
--- a/src/main/resources/wa-task-configuration-ia-asylum.dmn
+++ b/src/main/resources/wa-task-configuration-ia-asylum.dmn
@@ -184,6 +184,48 @@ else if caseData.appealType = "revocationOfProtection" then "Revocation" else ""
           <text>"upper_tribunal"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1dhhpyl">
+        <inputEntry id="UnaryTests_13pqmkc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10f3uas">
+          <text>"processApplication","reviewTheAppeal","decideOnTimeExtension","reviewRespondentEvidence","reviewAppealSkeletonArgument","reviewReasonsForAppeal","reviewClarifyingQuestionsAnswers","reviewCmaRequirements","attendCma","reviewRespondentResponse","createCaseSummary","createHearingBundle","startDecisionsAndReasonsDocument","reviewHearingRequirements","followUpOverdueRespondentEvidence","followUpOverdueCaseBuilding","followUpOverdueReasonsForAppeal","followUpOverdueClarifyingAnswers","followUpOverdueCmaRequirements","followUpOverdueRespondentReview","followUpOverdueHearingRequirements","followUpNonStandardDirection","followUpNoticeOfChange","reviewAdditionalEvidence","reviewAdditionalHomeOfficeEvidence"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_05l5bvs">
+          <text>"roleCategory"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_18y163a">
+          <text>"LEGAL_OPERATIONS"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_01muxrj">
+        <inputEntry id="UnaryTests_0ullysh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1glizm3">
+          <text>"arrangeOfflinePayment","markCaseAsPaid","addListingDate","allocateHearingJudge","uploadHearingRecording"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1131kat">
+          <text>"roleCategory"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0el7tae">
+          <text>"ADMINISTRATOR"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_01cmxvs">
+        <inputEntry id="UnaryTests_1np8ii5">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_15ftuu0">
+          <text>"reviewHearingBundle","generateDraftDecisionAndReasons","uploadDecision","reviewAddendumHomeOfficeEvidence","reviewAddendumAppellantEvidence","reviewAddendumEvidence"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_15nowth">
+          <text>"roleCategory"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1cn9cb2">
+          <text>"JUDICIAL"</text>
+        </outputEntry>
+      </rule>
     </decisionTable>
   </decision>
   <dmndi:DMNDI>

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskConfigurationTest.java
@@ -40,7 +40,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
     void if_this_test_fails_needs_updating_with_your_changes() {
         //The purpose of this test is to prevent adding new rows without being tested
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
-        assertThat(logic.getRules().size(), is(11));
+        assertThat(logic.getRules().size(), is(14));
     }
 
     @SuppressWarnings("checkstyle:indentation")
@@ -251,6 +251,83 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
     }
 
     @ParameterizedTest
+    @CsvSource({
+        "reviewHearingBundle","generateDraftDecisionAndReasons","uploadDecision","reviewAddendumHomeOfficeEvidence",
+        "reviewAddendumAppellantEvidence","reviewAddendumEvidence"
+    })
+    void when_taskId_then_return_judicial_role_category(String taskType) {
+        VariableMap inputVariables = new VariableMapImpl();
+
+        inputVariables.putValue("taskAttributes", Map.of("taskType", taskType));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .filter((r) -> r.containsValue("roleCategory"))
+            .collect(Collectors.toList());
+
+        assertEquals(1, workTypeResultList.size());
+
+        assertEquals(Map.of(
+            "name", "roleCategory",
+            "value", "JUDICIAL"
+        ), workTypeResultList.get(0));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "arrangeOfflinePayment","markCaseAsPaid","addListingDate","allocateHearingJudge","uploadHearingRecording"
+    })
+    void when_taskId_then_return_administrator_role_category(String taskType) {
+        VariableMap inputVariables = new VariableMapImpl();
+
+        inputVariables.putValue("taskAttributes", Map.of("taskType", taskType));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .filter((r) -> r.containsValue("roleCategory"))
+            .collect(Collectors.toList());
+
+        assertEquals(1, workTypeResultList.size());
+
+        assertEquals(Map.of(
+            "name", "roleCategory",
+            "value", "ADMINISTRATOR"
+        ), workTypeResultList.get(0));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "processApplication","reviewTheAppeal","decideOnTimeExtension","reviewRespondentEvidence",
+        "reviewAppealSkeletonArgument","reviewReasonsForAppeal","reviewClarifyingQuestionsAnswers",
+        "reviewCmaRequirements","attendCma","reviewRespondentResponse","createCaseSummary","createHearingBundle",
+        "startDecisionsAndReasonsDocument","reviewHearingRequirements","followUpOverdueRespondentEvidence",
+        "followUpOverdueCaseBuilding","followUpOverdueReasonsForAppeal","followUpOverdueClarifyingAnswers",
+        "followUpOverdueCmaRequirements","followUpOverdueRespondentReview","followUpOverdueHearingRequirements",
+        "followUpNonStandardDirection","followUpNoticeOfChange","reviewAdditionalEvidence",
+        "reviewAdditionalHomeOfficeEvidence"
+    })
+    void when_taskId_then_return_legal_operations_role_category(String taskType) {
+        VariableMap inputVariables = new VariableMapImpl();
+
+        inputVariables.putValue("taskAttributes", Map.of("taskType", taskType));
+
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .filter((r) -> r.containsValue("roleCategory"))
+            .collect(Collectors.toList());
+
+        assertEquals(1, workTypeResultList.size());
+
+        assertEquals(Map.of(
+            "name", "roleCategory",
+            "value", "LEGAL_OPERATIONS"
+        ), workTypeResultList.get(0));
+    }
+
+    @ParameterizedTest
     @MethodSource("nameAndValueScenarioProvider")
     void when_caseData_and_taskType_then_return_expected_name_and_value_rows(Scenario scenario) {
         VariableMap inputVariables = new VariableMapImpl();
@@ -321,6 +398,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
                 .expectedLocationNameValue("some other location name")
                 .expectedCaseManagementCategoryValue("Human rights")
                 .expectedWorkType("routine_work")
+                .expectedRoleCategory("ADMINISTRATOR")
                 .build();
 
         Scenario givenSomeCaseDataAndTaskTypeIsEmptyThenExpectNoWorkTypeRuleScenario =
@@ -359,6 +437,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
                 .expectedLocationNameValue("Taylor House")
                 .expectedCaseManagementCategoryValue("")
                 .expectedWorkType("routine_work")
+                .expectedRoleCategory("ADMINISTRATOR")
                 .build();
 
         return Stream.of(
@@ -382,6 +461,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
         String expectedLocationNameValue;
         String expectedCaseManagementCategoryValue;
         String expectedWorkType;
+        String expectedRoleCategory;
     }
 
     private List<Map<String, String>> getExpectedValues(Scenario scenario) {
@@ -396,6 +476,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
         if (!Objects.isNull(scenario.getTaskAttributes())
             && StringUtils.isNotBlank(scenario.taskAttributes.get("taskType").toString())) {
             getExpectedValue(rules, "workType", scenario.getExpectedWorkType());
+            getExpectedValue(rules, "roleCategory", scenario.getExpectedRoleCategory());
         }
 
         return rules;


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-945
<img width="1670" alt="Screenshot 2021-12-01 at 10 34 34" src="https://user-images.githubusercontent.com/581234/144219043-af94ac01-fbdc-4863-b9f5-3463f20af417.png">


### Change description ###

Populate role category on Task

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
