### PR TITLE
RIA-6101 Add updatePaymentStatus to trigger reviewTheAppeal

### DIFF
--- a/src/main/resources/wa-task-initiation-ia-asylum.dmn
+++ b/src/main/resources/wa-task-initiation-ia-asylum.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="wa-initiation-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.2.0">
   <decision id="wa-task-initiation-ia-asylum" name="Task initiation DMN">
     <decisionTable id="DecisionTable_0jtevuc" hitPolicy="COLLECT" biodi:annotationsWidth="400">
       <input id="Input_1" label="Event Id" biodi:width="515" camunda:inputVariable="eventId">
@@ -283,7 +283,8 @@
 "markAppealPaid",
 "moveToSubmitted",
 "payForAppeal",
-"recordRemissionDecision"          </text>
+"recordRemissionDecision",
+"updatePaymentStatus"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_08cfchy">
           <text>"appealSubmitted"</text>

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskInitiationTest.java
@@ -414,6 +414,42 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                 )
             ),
             Arguments.of(
+                "updatePaymentStatus",
+                "appealSubmitted",
+                mapAdditionalData("{\n"
+                                  + "   \"Data\":{\n"
+                                  + "      \"appealType\":\"" + "refusalOfEu" + "\"\n"
+                                  + "   }"
+                                  + "}"),
+                singletonList(
+                    Map.of(
+                        "taskId", "reviewTheAppeal",
+                        "name", "Review the appeal",
+
+                        "workingDaysAllowed", 2,
+                        "processCategories", "caseProgression"
+                    )
+                )
+            ),
+            Arguments.of(
+                "updatePaymentStatus",
+                "appealSubmitted",
+                mapAdditionalData("{\n"
+                                  + "   \"Data\":{\n"
+                                  + "      \"appealType\":\"" + "refusalOfHumanRights" + "\"\n"
+                                  + "   }"
+                                  + "}"),
+                singletonList(
+                    Map.of(
+                        "taskId", "reviewTheAppeal",
+                        "name", "Review the appeal",
+
+                        "workingDaysAllowed", 2,
+                        "processCategories", "caseProgression"
+                    )
+                )
+            ),
+            Arguments.of(
                 "submitTimeExtension",
                 "null",
                 null,


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6101](https://tools.hmcts.net/jira/browse/RIA-6101)


### Change description ###
- Make changes to the configuration so that reviewTheAppeal is triggered by:
  - **submitAppeal**-_appealSubmitted_ for PA cases
  - **updatePaymentStatus**-_appealSubmitted_ for HU & EA cases


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
