### PR TITLE
Ria 6101 vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,6 +215,11 @@ dependencyManagement {
       entry 'spring-jcl'
       entry 'spring-web'
     }
+
+    // CVE-2022-42003, CVE-2022-42004
+    dependency group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0-rc1'
+    dependency group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.0-rc1'
+    dependency group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.14.0-rc1'
   }
 }
 
@@ -234,7 +239,6 @@ def versions = [
   sonarPitest     : '0.5',
   tomcat          : '9.0.58',
   log4j           : '2.17.1'
-
 ]
 
 ext.libraries = [


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6101](https://tools.hmcts.net/jira/browse/RIA-6101)


### Change description ###
- Upgrade to latest versions for some jackson libraries to address CVE-2022-42003, CVE-2022-42004


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
