### PR TITLE
Ria 6704 fix to remove unclaim permission

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -117,6 +117,8 @@
   <suppress>
     <cve>CVE-2022-45143</cve>
     <cve>CVE-2021-4277</cve>
+    <cve>CVE-2022-3064</cve>
+    <cve>CVE-2021-4235</cve>
   </suppress>
 </suppressions>
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -95,5 +95,12 @@
     <cve>CVE-2022-41854</cve>
     <cve>CVE-2022-42252</cve>     
   </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[https://nvd.nist.gov/vuln/detail/CVE-2022-42252,
+    Apache Tomcat ]]>
+    </notes>
+    <cve>CVE-2022-42252</cve>
+  </suppress>
 </suppressions>
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -102,5 +102,17 @@
     </notes>
     <cve>CVE-2022-42252</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   tomcat-embed-core-9.0.58.jar and tomcat-embed-websocket-9.0.58.jar
+   ]]></notes>
+    <cve>CVE-2022-42252</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: snakeyaml-1.27.jar
+   ]]></notes>
+    <cve>CVE-2022-41854</cve>
+  </suppress>
 </suppressions>
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -89,11 +89,11 @@
     <cve>CVE-2022-38750</cve>
     <cve>CVE-2022-38749</cve>
     <cve>CVE-2022-38752</cve>
-    <cve>CVE-2021-43980</cve>  
+    <cve>CVE-2021-43980</cve>
   </suppress>
-  <suppress>  
+  <suppress>
     <cve>CVE-2022-41854</cve>
-    <cve>CVE-2022-42252</cve>     
+    <cve>CVE-2022-42252</cve>
   </suppress>
   <suppress>
     <notes>
@@ -113,6 +113,10 @@
    file name: snakeyaml-1.27.jar
    ]]></notes>
     <cve>CVE-2022-41854</cve>
+  </suppress>
+  <suppress>
+    <cve>CVE-2022-45143</cve>
+    <cve>CVE-2021-4277</cve>
   </suppress>
 </suppressions>
 

--- a/src/main/resources/wa-task-configuration-ia-asylum.dmn
+++ b/src/main/resources/wa-task-configuration-ia-asylum.dmn
@@ -311,7 +311,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1466etp">
-          <text>"followUpNoticeOfChange", "reviewSpecificAccessRequestJudiciary","reviewSpecificAccessRequestLegalOps","reviewSpecificAccessRequestAdmin"</text>
+          <text>"followUpNoticeOfChange", "reviewSpecificAccessRequestJudiciary","reviewSpecificAccessRequestLegalOps","reviewSpecificAccessRequestAdmin","reviewSpecificAccessRequestCTSC"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0bjcvtf">
           <text>"workType"</text>
@@ -328,7 +328,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0b3q932">
-          <text>"reviewSpecificAccessRequestJudiciary","reviewSpecificAccessRequestLegalOps","reviewSpecificAccessRequestAdmin"</text>
+          <text>"reviewSpecificAccessRequestJudiciary","reviewSpecificAccessRequestLegalOps","reviewSpecificAccessRequestAdmin","reviewSpecificAccessRequestCTSC"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1hrei14">
           <text>"additionalProperties_roleAssignmentId"</text>
@@ -406,7 +406,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_15ftuu0">
-          <text>"reviewHearingBundle","generateDraftDecisionAndReasons","uploadDecision","reviewAddendumHomeOfficeEvidence","reviewAddendumAppellantEvidence","reviewAddendumEvidence","reviewSpecificAccessRequestJudiciary","reviewSpecificAccessRequestLegalOps","reviewSpecificAccessRequestAdmin","processApplicationToReviewDecision","sendDecisionsAndReasons","prepareDecisionsAndReasons","decideAnFTPA"</text>
+          <text>"reviewHearingBundle","generateDraftDecisionAndReasons","uploadDecision","reviewAddendumHomeOfficeEvidence","reviewAddendumAppellantEvidence","reviewAddendumEvidence","reviewSpecificAccessRequestJudiciary","reviewSpecificAccessRequestLegalOps","reviewSpecificAccessRequestAdmin","reviewSpecificAccessRequestCTSC","processApplicationToReviewDecision","sendDecisionsAndReasons","prepareDecisionsAndReasons","decideAnFTPA"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_15nowth">
           <text>"roleCategory"</text>

--- a/src/main/resources/wa-task-permissions-ia-asylum.dmn
+++ b/src/main/resources/wa-task-permissions-ia-asylum.dmn
@@ -38,7 +38,7 @@
           <text>"task-supervisor"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1gda35a">
-          <text>"Read,Refer,Execute,Manage,Cancel"</text>
+          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0uxj36c">
           <text></text>
@@ -94,7 +94,7 @@
           <text>"case-manager"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0ekjswr">
-          <text>"Read,Refer,Own,Cancel"</text>
+          <text>"Read,Own,Claim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1tlohef">
           <text>"LEGAL_OPERATIONS"</text>
@@ -125,7 +125,7 @@
           <text>"tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_151ry1h">
-          <text>"Read,Refer,Own,Manage,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1rwokl1">
           <text>"LEGAL_OPERATIONS"</text>
@@ -181,7 +181,7 @@
           <text>"senior-tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1nhvpem">
-          <text>"Read,Refer,Own,Manage,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_03nq5c0">
           <text>"LEGAL_OPERATIONS"</text>
@@ -214,7 +214,7 @@
           <text>"judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1qa45z2">
-          <text>"Read,Refer,Execute,Manage,Cancel"</text>
+          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_06zjq08">
           <text>"JUDICIAL"</text>
@@ -247,7 +247,7 @@
           <text>"hearing-judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1g9ombg">
-          <text>"Read,Refer,Execute,Cancel"</text>
+          <text>"Read,Execute,Claim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_017of59">
           <text>"JUDICIAL"</text>
@@ -281,7 +281,7 @@
           <text>"hearing-centre-admin"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_18uxrkl">
-          <text>"Read,Refer,Own,Manage,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0fbgbzp">
           <text>"ADMIN"</text>
@@ -314,7 +314,7 @@
           <text>"tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1tlcgb1">
-          <text>"Read,Refer,Execute,Manage,Cancel"</text>
+          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1vwn7j0">
           <text>"LEGAL_OPERATIONS"</text>
@@ -347,7 +347,7 @@
           <text>"senior-tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0viqzzm">
-          <text>"Read,Refer,Execute,Manage,Cancel"</text>
+          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0feri8q">
           <text>"LEGAL_OPERATIONS"</text>
@@ -383,7 +383,7 @@
           <text>"hearing-judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_124xecb">
-          <text>"Read,Refer,Own,Cancel"</text>
+          <text>"Read,Own,Claim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1pkhxc7">
           <text>"JUDICIAL"</text>
@@ -420,7 +420,7 @@
           <text>"judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1n6hq4e">
-          <text>"Read,Refer,Own,Manage,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0pti6xc">
           <text>"JUDICIAL"</text>
@@ -450,7 +450,7 @@
           <text>"FTPA-judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0j0k6w4">
-          <text>"Read,Refer,Own,Cancel"</text>
+          <text>"Read,Own,Claim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0lym9xr">
           <text>"JUDICIAL"</text>
@@ -480,7 +480,7 @@
           <text>"tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_051fxvi">
-          <text>"Read,Refer,Own,Manage,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_02k1ff3">
           <text>"LEGAL_OPERATIONS"</text>
@@ -510,7 +510,7 @@
           <text>"senior-tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1w3llu8">
-          <text>"Read,Refer,Own,Manage,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1god3td">
           <text>"LEGAL_OPERATIONS"</text>
@@ -540,7 +540,7 @@
           <text>"leadership-judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1eu4g8m">
-          <text>"Read,Refer,Own,Manage,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_00y8zyo">
           <text>"JUDICIAL"</text>

--- a/src/main/resources/wa-task-permissions-ia-asylum.dmn
+++ b/src/main/resources/wa-task-permissions-ia-asylum.dmn
@@ -528,7 +528,7 @@
       <rule id="DecisionRule_1jyzdux">
         <description>Judge task permissions</description>
         <inputEntry id="UnaryTests_0pcvlxs">
-          <text>"reviewSpecificAccessRequestJudiciary", "reviewSpecificAccessRequestLegalOps","reviewSpecificAccessRequestAdmin"</text>
+          <text>"reviewSpecificAccessRequestJudiciary", "reviewSpecificAccessRequestLegalOps","reviewSpecificAccessRequestAdmin","reviewSpecificAccessRequestCTSC"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0ru9xxq">
           <text></text>

--- a/src/main/resources/wa-task-permissions-ia-asylum.dmn
+++ b/src/main/resources/wa-task-permissions-ia-asylum.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.2.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <decision id="wa-task-permissions-ia-asylum" name="Permissions DMN">
     <decisionTable id="DecisionTable_1pr5oic" hitPolicy="RULE ORDER">
       <input id="InputClause_12crj6e" label="Task Type" biodi:width="554" camunda:inputVariable="taskType">
@@ -38,7 +38,7 @@
           <text>"task-supervisor"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1gda35a">
-          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0uxj36c">
           <text></text>
@@ -125,7 +125,7 @@
           <text>"tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_151ry1h">
-          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1rwokl1">
           <text>"LEGAL_OPERATIONS"</text>
@@ -181,7 +181,7 @@
           <text>"senior-tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1nhvpem">
-          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_03nq5c0">
           <text>"LEGAL_OPERATIONS"</text>
@@ -214,7 +214,7 @@
           <text>"judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1qa45z2">
-          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_06zjq08">
           <text>"JUDICIAL"</text>
@@ -281,7 +281,7 @@
           <text>"hearing-centre-admin"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_18uxrkl">
-          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0fbgbzp">
           <text>"ADMIN"</text>
@@ -314,7 +314,7 @@
           <text>"tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1tlcgb1">
-          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1vwn7j0">
           <text>"LEGAL_OPERATIONS"</text>
@@ -347,7 +347,7 @@
           <text>"senior-tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0viqzzm">
-          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0feri8q">
           <text>"LEGAL_OPERATIONS"</text>
@@ -420,7 +420,7 @@
           <text>"judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1n6hq4e">
-          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0pti6xc">
           <text>"JUDICIAL"</text>
@@ -480,7 +480,7 @@
           <text>"tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_051fxvi">
-          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_02k1ff3">
           <text>"LEGAL_OPERATIONS"</text>
@@ -510,7 +510,7 @@
           <text>"senior-tribunal-caseworker"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1w3llu8">
-          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1god3td">
           <text>"LEGAL_OPERATIONS"</text>
@@ -540,7 +540,7 @@
           <text>"leadership-judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1eu4g8m">
-          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"</text>
+          <text>"Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_00y8zyo">
           <text>"JUDICIAL"</text>

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskConfigurationTest.java
@@ -229,7 +229,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
     @ParameterizedTest
     @CsvSource({
         "reviewSpecificAccessRequestJudiciary", "reviewSpecificAccessRequestLegalOps",
-        "reviewSpecificAccessRequestAdmin"
+        "reviewSpecificAccessRequestAdmin","reviewSpecificAccessRequestCTSC"
     })
     void when_taskId_then_return_Access_requests(String taskType) {
         VariableMap inputVariables = new VariableMapImpl();
@@ -255,7 +255,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
     @ParameterizedTest
     @CsvSource({
         "reviewSpecificAccessRequestJudiciary", "reviewSpecificAccessRequestLegalOps",
-        "reviewSpecificAccessRequestAdmin"
+        "reviewSpecificAccessRequestAdmin","reviewSpecificAccessRequestCTSC"
     })
     void should_return_request_value_when_role_assignment_id_exists_in_task_attributes(String taskType) {
         VariableMap inputVariables = new VariableMapImpl();
@@ -300,7 +300,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
     @CsvSource({
         "reviewHearingBundle", "generateDraftDecisionAndReasons", "uploadDecision", "reviewAddendumHomeOfficeEvidence",
         "reviewAddendumAppellantEvidence", "reviewAddendumEvidence", "reviewSpecificAccessRequestJudiciary",
-        "reviewSpecificAccessRequestLegalOps", "reviewSpecificAccessRequestAdmin",
+        "reviewSpecificAccessRequestLegalOps", "reviewSpecificAccessRequestAdmin","reviewSpecificAccessRequestCTSC",
         "processApplicationToReviewDecision", "sendDecisionsAndReasons", "prepareDecisionsAndReasons", "decideAnFTPA"
     })
     void when_taskId_then_return_judicial_role_category(String taskType) {
@@ -672,6 +672,8 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
         "reviewSpecificAccessRequestLegalOps,[Review Access Request](/role-access/"
             + "${[taskId]}/assignment/${[roleAssignmentId]}/specific-access),",
         "reviewSpecificAccessRequestAdmin,[Review Access Request](/role-access/"
+            + "${[taskId]}/assignment/${[roleAssignmentId]}/specific-access),",
+        "reviewSpecificAccessRequestCTSC,[Review Access Request](/role-access/"
             + "${[taskId]}/assignment/${[roleAssignmentId]}/specific-access),"
     })
     void should_return_a_200_description_property(String taskType, String expectedDescription, String journeyType) {

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskPermissionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskPermissionTest.java
@@ -40,7 +40,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
     private static final Map<String, Serializable> taskSupervisor = Map.of(
         "autoAssignable", false,
         "name", "task-supervisor",
-        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
+        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel"
     );
     private static final Map<String, Serializable> caseManager = Map.of(
         "autoAssignable", true,
@@ -53,28 +53,28 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         "assignmentPriority", 1,
         "name", "tribunal-caseworker",
         "roleCategory", "LEGAL_OPERATIONS",
-        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
+        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"
     );
     private static final Map<String, Serializable> tribunalCaseWorkerPriorityTwo = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 2,
         "name", "tribunal-caseworker",
         "roleCategory", "LEGAL_OPERATIONS",
-        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
+        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel"
     );
     private static final Map<String, Serializable> seniorCaseWorkerPriorityOne = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 1,
         "name", "senior-tribunal-caseworker",
         "roleCategory", "LEGAL_OPERATIONS",
-        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
+        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"
     );
     private static final Map<String, Serializable> seniorCaseWorkerPriorityTwo = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 2,
         "name", "senior-tribunal-caseworker",
         "roleCategory", "LEGAL_OPERATIONS",
-        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
+        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel"
     );
     private static final Map<String, Serializable> judgePriorityTwo = Map.of(
         "autoAssignable", false,
@@ -82,7 +82,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         "authorisations", "373",
         "name", "judge",
         "roleCategory", "JUDICIAL",
-        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
+        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel"
     );
     private static final Map<String, Serializable> hearingJudgePriorityOne = Map.of(
         "autoAssignable", true,
@@ -104,14 +104,14 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         "authorisations", "373",
         "name", "judge",
         "roleCategory", "JUDICIAL",
-        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
+        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"
     );
 
     private static final Map<String, Serializable> hearingCentreAdminPriorityOne = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 1,
         "name", "hearing-centre-admin",
-        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel",
         "roleCategory", "ADMIN"
     );
     private static final Map<String, Serializable> ftpaJudgePriorityOne = Map.of(
@@ -223,7 +223,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 List.of(
                     Map.of(
                         "name", "task-supervisor",
-                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                         "autoAssignable", false
                     )
                 )
@@ -234,7 +234,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 List.of(
                     Map.of(
                         "name", "task-supervisor",
-                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                         "autoAssignable", false
                     )
                 )
@@ -245,7 +245,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 List.of(
                     Map.of(
                         "name", "task-supervisor",
-                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                         "autoAssignable", false
                     )
                 )
@@ -256,7 +256,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 List.of(
                     Map.of(
                         "name", "task-supervisor",
-                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                         "autoAssignable", false
                     )
                 )
@@ -301,7 +301,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "autoAssignable", false
             ), Map.of(
                 "name", "case-manager",
@@ -311,14 +311,14 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
             ),
             Map.of(
                 "name", "tribunal-caseworker",
-                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 1,
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "senior-tribunal-caseworker",
-                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 1,
                 "autoAssignable", false
@@ -340,7 +340,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "autoAssignable", false
             ), Map.of(
                 "name", "case-manager",
@@ -350,14 +350,14 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
             ),
             Map.of(
                 "name", "tribunal-caseworker",
-                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 1,
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "senior-tribunal-caseworker",
-                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 1,
                 "autoAssignable", false
@@ -379,26 +379,26 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "hearing-centre-admin",
-                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "roleCategory", "ADMIN",
                 "assignmentPriority", 1,
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "tribunal-caseworker",
-                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 2,
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "senior-tribunal-caseworker",
-                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 2,
                 "autoAssignable", false
@@ -420,7 +420,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "autoAssignable", false
             ),
             Map.of(
@@ -436,7 +436,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 "authorisations", "373",
                 "name", "judge",
                 "roleCategory", "JUDICIAL",
-                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel"
             )
         )));
     }
@@ -451,18 +451,18 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "tribunal-caseworker",
-                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "senior-tribunal-caseworker",
-                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "autoAssignable", false
             )

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskPermissionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskPermissionTest.java
@@ -31,7 +31,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
 
     private static final Map<String, Serializable> nationalBusinessCentre = Map.of(
         "name", "national-business-centre",
-        "value", "Read,Refer,Own",
+        "value", "Read,Own,Claim",
         "roleCategory", "ADMIN",
         "assignmentPriority", 1,
         "autoAssignable", false
@@ -40,41 +40,41 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
     private static final Map<String, Serializable> taskSupervisor = Map.of(
         "autoAssignable", false,
         "name", "task-supervisor",
-        "value", "Read,Refer,Execute,Manage,Cancel"
+        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
     );
     private static final Map<String, Serializable> caseManager = Map.of(
         "autoAssignable", true,
         "name", "case-manager",
         "roleCategory", "LEGAL_OPERATIONS",
-        "value", "Read,Refer,Own,Cancel"
+        "value", "Read,Own,Claim,Cancel"
     );
     private static final Map<String, Serializable> tribunalCaseWorkerPriorityOne = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 1,
         "name", "tribunal-caseworker",
         "roleCategory", "LEGAL_OPERATIONS",
-        "value", "Read,Refer,Own,Manage,Cancel"
+        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
     );
     private static final Map<String, Serializable> tribunalCaseWorkerPriorityTwo = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 2,
         "name", "tribunal-caseworker",
         "roleCategory", "LEGAL_OPERATIONS",
-        "value", "Read,Refer,Execute,Manage,Cancel"
+        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
     );
     private static final Map<String, Serializable> seniorCaseWorkerPriorityOne = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 1,
         "name", "senior-tribunal-caseworker",
         "roleCategory", "LEGAL_OPERATIONS",
-        "value", "Read,Refer,Own,Manage,Cancel"
+        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
     );
     private static final Map<String, Serializable> seniorCaseWorkerPriorityTwo = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 2,
         "name", "senior-tribunal-caseworker",
         "roleCategory", "LEGAL_OPERATIONS",
-        "value", "Read,Refer,Execute,Manage,Cancel"
+        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
     );
     private static final Map<String, Serializable> judgePriorityTwo = Map.of(
         "autoAssignable", false,
@@ -82,21 +82,21 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         "authorisations", "373",
         "name", "judge",
         "roleCategory", "JUDICIAL",
-        "value", "Read,Refer,Execute,Manage,Cancel"
+        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
     );
     private static final Map<String, Serializable> hearingJudgePriorityOne = Map.of(
         "autoAssignable", true,
         "assignmentPriority", 1,
         "name", "hearing-judge",
         "roleCategory", "JUDICIAL",
-        "value", "Read,Refer,Own,Cancel"
+        "value", "Read,Own,Claim,Cancel"
     );
     private static final Map<String, Serializable> hearingJudgePriorityTwo = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 2,
         "name", "hearing-judge",
         "roleCategory", "JUDICIAL",
-        "value", "Read,Refer,Execute,Cancel"
+        "value", "Read,Execute,Claim,Cancel"
     );
     private static final Map<String, Serializable> judgePriorityOne = Map.of(
         "autoAssignable", false,
@@ -104,14 +104,14 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         "authorisations", "373",
         "name", "judge",
         "roleCategory", "JUDICIAL",
-        "value", "Read,Refer,Own,Manage,Cancel"
+        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
     );
 
     private static final Map<String, Serializable> hearingCentreAdminPriorityOne = Map.of(
         "autoAssignable", false,
         "assignmentPriority", 1,
         "name", "hearing-centre-admin",
-        "value", "Read,Refer,Own,Manage,Cancel",
+        "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
         "roleCategory", "ADMIN"
     );
     private static final Map<String, Serializable> ftpaJudgePriorityOne = Map.of(
@@ -119,7 +119,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         "assignmentPriority", 1,
         "name", "FTPA-judge",
         "roleCategory", "JUDICIAL",
-        "value", "Read,Refer,Own,Cancel"
+        "value", "Read,Own,Claim,Cancel"
     );
 
     @BeforeAll
@@ -223,7 +223,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 List.of(
                     Map.of(
                         "name", "task-supervisor",
-                        "value", "Read,Refer,Execute,Manage,Cancel",
+                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                         "autoAssignable", false
                     )
                 )
@@ -234,7 +234,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 List.of(
                     Map.of(
                         "name", "task-supervisor",
-                        "value", "Read,Refer,Execute,Manage,Cancel",
+                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                         "autoAssignable", false
                     )
                 )
@@ -245,7 +245,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 List.of(
                     Map.of(
                         "name", "task-supervisor",
-                        "value", "Read,Refer,Execute,Manage,Cancel",
+                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                         "autoAssignable", false
                     )
                 )
@@ -256,7 +256,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 List.of(
                     Map.of(
                         "name", "task-supervisor",
-                        "value", "Read,Refer,Execute,Manage,Cancel",
+                        "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                         "autoAssignable", false
                     )
                 )
@@ -301,24 +301,24 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Refer,Execute,Manage,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "autoAssignable", false
             ), Map.of(
                 "name", "case-manager",
-                "value", "Read,Refer,Own,Cancel",
+                "value", "Read,Own,Claim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "autoAssignable", true
             ),
             Map.of(
                 "name", "tribunal-caseworker",
-                "value", "Read,Refer,Own,Manage,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 1,
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "senior-tribunal-caseworker",
-                "value", "Read,Refer,Own,Manage,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 1,
                 "autoAssignable", false
@@ -340,24 +340,24 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Refer,Execute,Manage,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "autoAssignable", false
             ), Map.of(
                 "name", "case-manager",
-                "value", "Read,Refer,Own,Cancel",
+                "value", "Read,Own,Claim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "autoAssignable", true
             ),
             Map.of(
                 "name", "tribunal-caseworker",
-                "value", "Read,Refer,Own,Manage,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 1,
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "senior-tribunal-caseworker",
-                "value", "Read,Refer,Own,Manage,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 1,
                 "autoAssignable", false
@@ -379,26 +379,26 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Refer,Execute,Manage,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "hearing-centre-admin",
-                "value", "Read,Refer,Own,Manage,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "roleCategory", "ADMIN",
                 "assignmentPriority", 1,
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "tribunal-caseworker",
-                "value", "Read,Refer,Execute,Manage,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 2,
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "senior-tribunal-caseworker",
-                "value", "Read,Refer,Execute,Manage,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "assignmentPriority", 2,
                 "autoAssignable", false
@@ -420,7 +420,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Refer,Execute,Manage,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "autoAssignable", false
             ),
             Map.of(
@@ -428,7 +428,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 "assignmentPriority", 1,
                 "name", "hearing-judge",
                 "roleCategory", "JUDICIAL",
-                "value", "Read,Refer,Own,Cancel"
+                "value", "Read,Own,Claim,Cancel"
             ),
             Map.of(
                 "autoAssignable", false,
@@ -436,7 +436,7 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
                 "authorisations", "373",
                 "name", "judge",
                 "roleCategory", "JUDICIAL",
-                "value", "Read,Refer,Own,Manage,Cancel"
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel"
             )
         )));
     }
@@ -451,18 +451,18 @@ class CamundaTaskPermissionTest extends DmnDecisionTableBaseUnitTest {
         MatcherAssert.assertThat(dmnDecisionTableResult.getResultList(), is(List.of(
             Map.of(
                 "name", "task-supervisor",
-                "value", "Read,Refer,Execute,Manage,Cancel",
+                "value", "Read,Execute,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "tribunal-caseworker",
-                "value", "Read,Refer,Own,Manage,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "autoAssignable", false
             ),
             Map.of(
                 "name", "senior-tribunal-caseworker",
-                "value", "Read,Refer,Own,Manage,Cancel",
+                "value", "Read,Own,Claim,Manage,Unassign,Assign,Complete,Unclaim,Cancel",
                 "roleCategory", "LEGAL_OPERATIONS",
                 "autoAssignable", false
             )


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6704

### Change description ###

Fix to remove unclaim redundant permission from DMN, as both Unassign and Unclaim are the same.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
