### PR TITLE
RIA-0000 java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ repositories {
 }
 
 def versions = [
-  reformLogging   : '5.1.7',
+  reformLogging   : '6.0.1',
   springfoxSwagger: '3.0.0',
   camunda         : '7.15.0',
   pitest          : '1.9.11',


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.