### PR TITLE
RIA-8632 Due date for CMR tasks (send and update) 2 days

### DIFF
--- a/src/main/resources/wa-task-configuration-ia-asylum.dmn
+++ b/src/main/resources/wa-task-configuration-ia-asylum.dmn
@@ -645,7 +645,9 @@
 "reviewAddendumEvidence",
 "reviewRemissionApplication",
 "assignAFTPAJudge",
-"listTheCase"</text>
+"listTheCase",
+"cmrListed",
+"cmrUpdated"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1kbin0j">
           <text>"dueDateIntervalDays"</text>

--- a/src/main/resources/wa-task-initiation-ia-asylum.dmn
+++ b/src/main/resources/wa-task-initiation-ia-asylum.dmn
@@ -3799,10 +3799,7 @@
           <text>"Send CMR notification"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_18rjlnm">
-          <text>{
-"delayUntilOrigin": today(),
-"delayUntilIntervalDays":"2"
-}</text>
+          <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0kdv6sd">
           <text>"caseProgression"</text>
@@ -3864,10 +3861,7 @@
           <text>"Update CMR notification"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0m0f9jh">
-          <text>{
-"delayUntilOrigin": today(),
-"delayUntilIntervalDays":"2"
-}</text>
+          <text></text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1ovuvug">
           <text>"caseProgression"</text>

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskConfigurationTest.java
@@ -1167,7 +1167,9 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
             Arguments.of("sendPaymentRequest", zeroDays),
             Arguments.of("uploadHearingRecording", zeroDays),
             Arguments.of("decideAnFTPA", zeroDays),
-            Arguments.of("markAsPaid", fourteenDays)
+            Arguments.of("markAsPaid", fourteenDays),
+            Arguments.of("cmrListed", twoDays),
+            Arguments.of("cmrUpdated", twoDays)
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskInitiationTest.java
@@ -59,11 +59,6 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
             "delayUntilOrigin", LocalDate.now()
         );
 
-        Map<String,Object> delayFor2Days = Map.of(
-            "delayUntilIntervalDays", "2",
-            "delayUntilOrigin", LocalDate.now()
-        );
-
         return Stream.of(
             Arguments.of(
                 "applyForFTPAAppellant",
@@ -1680,7 +1675,6 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskId", "cmrUpdated",
                         "name", "Update CMR notification",
-                        "delayUntil", delayFor2Days,
 
                         "processCategories", "caseProgression"
                     )
@@ -1732,7 +1726,6 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskId", "cmrListed",
                         "name", "Send CMR notification",
-                        "delayUntil", delayFor2Days,
 
                         "processCategories", "caseProgression"
                     )


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8632](https://tools.hmcts.net/jira/browse/RIA-8632)


### Change description ###
- Undid previous changes introducing a 2 days delay for `cmrListed` and `cmrUpdated` and made the tasks have a _due date_ of 2 days


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x No
```
