### PR TITLE
RIA-9267  add adjournHearingWithoutDate

### DIFF
--- a/src/main/resources/wa-task-cancellation-ia-asylum.dmn
+++ b/src/main/resources/wa-task-cancellation-ia-asylum.dmn
@@ -597,6 +597,29 @@
           <text></text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_0zzsez4">
+        <inputEntry id="UnaryTests_1emr3fh">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1qyacq4">
+          <text>"adjournHearingWithoutDate"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jjg5od">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_00h4vda">
+          <text>"Reconfigure"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1bbeaf1">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_00f19yj">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_127x3nu">
+          <text></text>
+        </outputEntry>
+      </rule>
     </decisionTable>
   </decision>
   <dmndi:DMNDI>

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskCancellationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskCancellationTest.java
@@ -305,6 +305,16 @@ class CamundaTaskCancellationTest extends DmnDecisionTableBaseUnitTest {
                         "action", "Reconfigure"
                     )
                 )
+            ),
+            Arguments.of(
+                null,
+                "adjournHearingWithoutDate",
+                null,
+                singletonList(
+                    Map.of(
+                        "action", "Reconfigure"
+                    )
+                )
             )
         );
     }
@@ -331,7 +341,7 @@ class CamundaTaskCancellationTest extends DmnDecisionTableBaseUnitTest {
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
         assertThat(logic.getInputs().size(), is(3));
         assertThat(logic.getOutputs().size(), is(4));
-        assertThat(logic.getRules().size(), is(25));
+        assertThat(logic.getRules().size(), is(26));
 
     }
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-9267


### Change description ###
Refactor existing CCD events to support next hearing date calculation, added adjournHearingWithoutDate to dmn cancellation


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
