### PR TITLE
DIAC-1076 add migrateCase event for PA appeals in appealSubmitted state

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <cve>CVE-2024-38820</cve>
+    <cve>CVE-2024-38286</cve>
+    <cve>CVE-2025-24813</cve>
+  </suppress>
 </suppressions>
 

--- a/src/main/resources/wa-task-initiation-ia-asylum.dmn
+++ b/src/main/resources/wa-task-initiation-ia-asylum.dmn
@@ -1582,7 +1582,8 @@
         <inputEntry id="UnaryTests_116xfi4">
           <text>"submitAppeal",
 "payAndSubmitAppeal",
-"progressMigratedCase"</text>
+"progressMigratedCase",
+"migrateCase"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_07uxcvq">
           <text>"appealSubmitted"</text>

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskInitiationTest.java
@@ -324,6 +324,24 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                 )
             ),
             Arguments.of(
+                "migrateCase",
+                "appealSubmitted",
+                mapAdditionalData("{\n"
+                                      + "   \"Data\":{\n"
+                                      + "      \"appealType\":\"" + "protection" + "\",\n"
+                                      + "      \"journeyType\":\"" + "aip" + "\"\n"
+                                      + "   }"
+                                      + "}"),
+                singletonList(
+                    Map.of(
+                        "taskId", "reviewTheAppeal",
+                        "name", "Review the appeal",
+
+                        "processCategories", "caseProgression"
+                    )
+                )
+            ),
+            Arguments.of(
                 "submitAppeal",
                 "appealSubmitted",
                 mapAdditionalData("{\n"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DIAC-1076

### Change description ###
Update "reviewTheAppeal" task initiation dmn file to create WA task when PA appeals are progressed to "appealSubmitted" state using migrateCase event.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
