### PR TITLE
DIAC-1076 Remove "migrateCase" event for protection appeals "reviewTheAppeal" task

### DIFF
--- a/src/main/resources/wa-task-initiation-ia-asylum.dmn
+++ b/src/main/resources/wa-task-initiation-ia-asylum.dmn
@@ -1582,8 +1582,7 @@
         <inputEntry id="UnaryTests_116xfi4">
           <text>"submitAppeal",
 "payAndSubmitAppeal",
-"progressMigratedCase",
-"migrateCase"</text>
+"progressMigratedCase"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_07uxcvq">
           <text>"appealSubmitted"</text>

--- a/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iataskconfiguration/dmn/CamundaTaskInitiationTest.java
@@ -324,24 +324,6 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                 )
             ),
             Arguments.of(
-                "migrateCase",
-                "appealSubmitted",
-                mapAdditionalData("{\n"
-                                      + "   \"Data\":{\n"
-                                      + "      \"appealType\":\"" + "protection" + "\",\n"
-                                      + "      \"journeyType\":\"" + "aip" + "\"\n"
-                                      + "   }"
-                                      + "}"),
-                singletonList(
-                    Map.of(
-                        "taskId", "reviewTheAppeal",
-                        "name", "Review the appeal",
-
-                        "processCategories", "caseProgression"
-                    )
-                )
-            ),
-            Arguments.of(
                 "submitAppeal",
                 "appealSubmitted",
                 mapAdditionalData("{\n"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DIAC-1076


### Change description ###
Remove "migrateCase" event for protection appeals "reviewTheAppeal" task, as the DB migration for PA appeals is complete.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
